### PR TITLE
docs: add Phase 6-8 to roadmap (DX, observability, workflow)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,6 +114,91 @@ src/
 - [ ] `egret logs <container>` — 特定コンテナのログ表示
 - [x] Ctrl+C グレースフルシャットダウン（tokio signal handling）— Phase 1 で実装済み
 
+### Phase 6: バリデーション + Init + Dry-run
+**目標**: コンテナ起動前にエラーを検出し、プロジェクト開始を高速化する
+
+> Phase 3-5 と並行して着手可能（既存の `taskdef` / `overrides` モジュールのみに依存）
+
+- [ ] `egret validate` — タスク定義の静的解析
+  - イメージ名形式チェック、ポートマッピング競合検出
+  - `dependsOn` 参照先の存在チェック、循環依存検出
+  - Secret ARN 形式バリデーション
+  - オーバーライドファイルのコンテナ名検証
+  - よくあるミスへの警告（全コンテナ essential=false、ポートマッピングなし等）
+- [ ] `egret init` — スターターファイル生成
+  - 最小限のタスク定義 JSON、`egret-override.json`、`secrets.local.json` のテンプレート
+  - `--image` / `--family` フラグによる非対話生成
+- [ ] `--dry-run` フラグ（`egret run`）
+  - パース → バリデーション → オーバーライド適用 → Secrets 解決 → 構成表示（起動はしない）
+  - コンテナ名、イメージ、環境変数（secrets 値は伏字）、ポート、ネットワーク名を出力
+- [ ] リッチなバリデーションエラーメッセージ
+  - フィールドパス、期待される型、修正提案を含む人間向けの診断出力
+
+### Phase 7: 可観測性 + 診断
+**目標**: 実行中タスクの状態・リソース使用量・履歴を可視化し、ローカルデバッグを支援する
+
+> Phase 5 完了後に着手（ログ基盤・ps コマンドの存在が前提）
+
+- [ ] 強化版 `egret ps`
+  - ヘルスチェック状態（HEALTHY/UNHEALTHY/UNKNOWN）、ポートマッピング、起動時間
+  - CPU/メモリ使用量スナップショット（`docker stats` 相当）
+  - 依存関係グラフ上の位置
+  - 出力形式: table（デフォルト）、`--output json`、`--output wide`
+- [ ] `egret inspect <family>` — 実行中タスクの詳細表示
+  - マージ済み実効設定（タスク定義 + オーバーライド + 解決済み Secrets、値は伏字）
+  - ネットワークトポロジ、メタデータエンドポイント URL、コンテナ ID・イメージダイジェスト
+- [ ] `egret stats [family]` — ライブリソース使用量表示
+  - CPU%、メモリ使用量、ネットワーク I/O、ブロック I/O をリアルタイム更新
+  - bollard の stats stream 利用、`--interval`（デフォルト 2s）、`--no-stream`（単発モード）
+- [ ] `egret history` — 実行履歴の記録・表示
+  - `~/.egret/history.json` に保存（family、開始時刻、所要時間、終了状態、コンテナ数）
+  - `egret history --clear` でリセット
+- [ ] 構造化イベントログ
+  - ライフサイクルイベント（作成、起動、ヘルスチェック通過/失敗、終了、クリーンアップ完了）
+  - `--events` フラグで NDJSON 形式を stderr に出力（外部ツール連携用）
+
+### Phase 8: ワークフロー高速化
+**目標**: edit-run-debug サイクルを短縮する
+
+> Phase 6 完了後に着手、Phase 7 と並行可能
+
+- [ ] `egret watch` — ファイル変更監視 + 自動再起動
+  - タスク定義、オーバーライド、secrets ファイルの変更を検知
+  - 変更時: 停止 → 再パース → 再バリデーション → 再起動
+  - デバウンス付き（デフォルト 500ms、`--debounce` で変更可能）
+  - `--watch-path` でアプリソース等の追加監視パスを指定可能
+- [ ] `egret diff <file1> <file2>` — タスク定義のセマンティック diff
+  - テキスト diff ではなく、コンテナ・環境変数・ポート単位の意味的差分
+  - 色付きターミナル出力（追加/削除/変更を表示）
+- [ ] 設定プロファイル（`--profile`）
+  - `--profile dev` で `egret-override.dev.json` / `secrets.dev.json` を自動ロード
+  - `.egret.toml` でデフォルトプロファイル・タスク定義パスを設定
+- [ ] `egret compose-import <docker-compose.yml>` — Compose → ECS タスク定義変換
+  - 一方向変換: services → containerDefinitions、ports、environment、depends_on → dependsOn
+  - 非対応 Compose 機能（build、extends 等）は警告表示
+- [ ] `egret completions <shell>` — シェル補完スクリプト生成
+  - bash / zsh / fish 対応（`clap_complete` 利用）
+
+---
+
+## 実装順序とPhase間の依存関係
+
+```
+Phase 0-2.5: ✅ 完了
+    │
+    ├── Phase 6 (Validate/Init/Dry-run) ← 今すぐ着手可能、Phase 3-5 と並行
+    │
+    ├── Phase 3 (Metadata + Credentials)
+    │       │
+    ├── Phase 4 (dependsOn + Health Check)
+    │       │
+    └── Phase 5 (Volumes + Logs + ps)
+            │
+            ├── Phase 7 (可観測性) ← Phase 5 完了後
+            │
+            └── Phase 8 (ワークフロー高速化) ← Phase 6 完了後、Phase 7 と並行可
+```
+
 ---
 
 ## 対象外（明示的に除外）
@@ -123,3 +208,7 @@ src/
 - Capacity providers / Deployment circuit breaker
 - FireLens 本番同等挙動
 - Service / Auto Scaling / ローリングデプロイ
+- コンテナイメージのビルド（Docker/Buildah/Kaniko の責務）
+- Prometheus / Grafana 等の外部監視スタック連携
+- awsvpc ネットワークモード完全再現
+- Service Mesh / Service Connect

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -97,6 +97,36 @@ ECS タスク定義をローカルで実行し、ECS アプリが期待する実
 | FR-9.3 | `egret ps` で実行中タスク一覧を表示する | 🔲 未実装 |
 | FR-9.4 | `egret logs <container>` で特定コンテナのログを表示する | 🔲 未実装 |
 
+### FR-10: バリデーション + プロジェクト初期化
+
+| ID | 要件 | 状態 |
+|----|------|------|
+| FR-10.1 | `egret validate` でタスク定義を静的解析できる（イメージ形式、ポート競合、ARN形式等） | 🔲 未実装 |
+| FR-10.2 | `egret init` でスターターファイル（タスク定義、override、secrets テンプレート）を生成できる | 🔲 未実装 |
+| FR-10.3 | `--dry-run` で起動せずにコンテナ構成を確認できる（secrets 値は伏字） | 🔲 未実装 |
+| FR-10.4 | バリデーションエラーにフィールドパス・期待型・修正提案を含める | 🔲 未実装 |
+
+### FR-11: 可観測性 + 診断
+
+| ID | 要件 | 状態 |
+|----|------|------|
+| FR-11.1 | `egret ps` でリソース使用量・ヘルスチェック状態・依存関係を表示できる | 🔲 未実装 |
+| FR-11.2 | `egret ps` の出力形式を `--output json/wide` で切り替えできる | 🔲 未実装 |
+| FR-11.3 | `egret inspect` で実行中タスクの詳細（実効設定、ネットワーク構成）を表示できる | 🔲 未実装 |
+| FR-11.4 | `egret stats` でライブリソース使用量（CPU、メモリ、I/O）を表示できる | 🔲 未実装 |
+| FR-11.5 | `egret history` で実行履歴を記録・表示できる | 🔲 未実装 |
+| FR-11.6 | `--events` でライフサイクルイベントを NDJSON 形式で出力できる | 🔲 未実装 |
+
+### FR-12: ワークフロー高速化
+
+| ID | 要件 | 状態 |
+|----|------|------|
+| FR-12.1 | `egret watch` でファイル変更時にタスクを自動再起動できる | 🔲 未実装 |
+| FR-12.2 | `egret diff` でタスク定義をセマンティックに比較できる | 🔲 未実装 |
+| FR-12.3 | `--profile` で設定プロファイル（override + secrets）を切り替えできる | 🔲 未実装 |
+| FR-12.4 | `egret compose-import` で docker-compose.yml を ECS タスク定義に変換できる | 🔲 未実装 |
+| FR-12.5 | `egret completions` でシェル補完スクリプト（bash/zsh/fish）を生成できる | 🔲 未実装 |
+
 ---
 
 ## 非機能要件
@@ -119,3 +149,7 @@ ECS タスク定義をローカルで実行し、ECS アプリが期待する実
 - Capacity providers / Deployment circuit breaker
 - FireLens 本番同等挙動
 - Service / Auto Scaling / ローリングデプロイ
+- コンテナイメージのビルド（Docker/Buildah/Kaniko の責務）
+- Prometheus / Grafana 等の外部監視スタック連携
+- awsvpc ネットワークモード完全再現
+- Service Mesh / Service Connect


### PR DESCRIPTION
Add three new phases to the roadmap and requirements:
- Phase 6: Validation + Init + Dry-run (parallelizable with Phase 3-5)
- Phase 7: Observability + Diagnostics (post Phase 5)
- Phase 8: Workflow Acceleration (post Phase 6, parallel to Phase 7)

Also expand the out-of-scope section with additional exclusions.

https://claude.ai/code/session_01WkysTGrocp9Db7AhZH57Xp