### PR TITLE
feat: configure Claude Code settings (reasoning:high, japanese, permi…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,11 @@
-{}
+{
+  "effortLevel": "high",
+  "language": "japanese",
+  "permissions": {
+    "allow": [
+      "Bash(make:*)",
+      "Bash(cargo:*)",
+      "Bash(git:*)"
+    ]
+  }
+}


### PR DESCRIPTION
…ssions)

- effortLevel: high for deeper reasoning
- language: japanese for Japanese responses
- permissions: allow make/cargo/git commands without prompting

https://claude.ai/code/session_01XCDQ92S9dSm8H8YvVMq1Db