### PR TITLE
perf: configure lld linker for faster builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]


### PR DESCRIPTION
Add .cargo/config.toml with lld linker setting for x86_64-unknown-linux-gnu.
This reduces link times during development builds.

https://claude.ai/code/session_016rubZo9KR9Eh3D4rgAmBbW