### PR TITLE
feat: add property-based tests with proptest for high-priority modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1416,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.4",
  "notify",
+ "proptest",
  "reqwest",
  "serde",
  "serde_json",
@@ -1617,6 +1633,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +1709,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1713,6 +1754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1892,6 +1942,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2502,6 +2564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2638,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ notify = "8"
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tempfile = "3"
+proptest = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -28,6 +28,7 @@ pub enum OrchestratorError {
 }
 
 /// Lightweight dependency information for DAG resolution.
+#[derive(Debug, Clone)]
 pub struct DependencyInfo {
     pub name: String,
     pub depends_on: Vec<DependsOn>,
@@ -893,6 +894,246 @@ mod tests {
     fn format_cycle_path_short_input() {
         assert_eq!(format_cycle_path(&[]), "unknown cycle");
         assert_eq!(format_cycle_path(&["a"]), "unknown cycle");
+    }
+
+    // --- Property-based tests for DAG resolution ---
+
+    mod pbt {
+        use super::*;
+        use proptest::prelude::*;
+        use std::collections::{HashMap, HashSet};
+
+        /// Generate a list of unique container names (`1..=max_nodes`).
+        fn arb_container_names(max_nodes: usize) -> impl Strategy<Value = Vec<String>> {
+            (1..=max_nodes).prop_flat_map(|n| {
+                proptest::collection::vec("[a-z][a-z0-9]{0,7}", n..=n).prop_map(|names| {
+                    // Deduplicate
+                    let mut seen = HashSet::new();
+                    let mut unique = Vec::new();
+                    for (i, name) in names.into_iter().enumerate() {
+                        let candidate = if seen.contains(&name) {
+                            format!("{name}{i}")
+                        } else {
+                            name
+                        };
+                        seen.insert(candidate.clone());
+                        unique.push(candidate);
+                    }
+                    unique
+                })
+            })
+        }
+
+        /// Generate a valid DAG (no cycles): for each node, only depend on nodes
+        /// with a smaller index (guarantees topological ordering).
+        fn arb_dag(max_nodes: usize) -> impl Strategy<Value = Vec<DependencyInfo>> {
+            arb_container_names(max_nodes).prop_flat_map(|names| {
+                let n = names.len();
+                let deps_strategies: Vec<_> = (0..n)
+                    .map(|i| {
+                        if i == 0 {
+                            // First node cannot depend on anything
+                            Just(vec![]).boxed()
+                        } else {
+                            // Depend on a subset of earlier nodes (0 to min(i, 3) deps)
+                            let max_deps = i.min(3);
+                            proptest::collection::vec(0..i, 0..=max_deps)
+                                .prop_map(|indices| {
+                                    let mut seen = HashSet::new();
+                                    indices
+                                        .into_iter()
+                                        .filter(|idx| seen.insert(*idx))
+                                        .collect::<Vec<_>>()
+                                })
+                                .boxed()
+                        }
+                    })
+                    .collect();
+
+                (Just(names), deps_strategies).prop_map(|(names, dep_indices_vec)| {
+                    names
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| DependencyInfo {
+                            name: name.clone(),
+                            depends_on: dep_indices_vec[i]
+                                .iter()
+                                .map(|&idx| DependsOn {
+                                    container_name: names[idx].clone(),
+                                    condition: DependencyCondition::Start,
+                                })
+                                .collect(),
+                        })
+                        .collect()
+                })
+            })
+        }
+
+        /// Generate a dependency graph that contains at least one cycle.
+        fn arb_cyclic_graph() -> impl Strategy<Value = Vec<DependencyInfo>> {
+            arb_container_names(6).prop_flat_map(|names| {
+                let n = names.len();
+                if n < 2 {
+                    // Need at least 2 nodes for a cycle
+                    return Just(vec![
+                        DependencyInfo {
+                            name: "cyc_a".into(),
+                            depends_on: vec![DependsOn {
+                                container_name: "cyc_b".into(),
+                                condition: DependencyCondition::Start,
+                            }],
+                        },
+                        DependencyInfo {
+                            name: "cyc_b".into(),
+                            depends_on: vec![DependsOn {
+                                container_name: "cyc_a".into(),
+                                condition: DependencyCondition::Start,
+                            }],
+                        },
+                    ])
+                    .boxed();
+                }
+
+                // Pick a cycle length (2..=n), then create a cycle among
+                // the first `cycle_len` nodes and leave the rest independent.
+                (2..=n)
+                    .prop_flat_map(move |cycle_len| {
+                        let names = names.clone();
+                        Just(
+                            names
+                                .iter()
+                                .enumerate()
+                                .map(|(i, name)| {
+                                    if i < cycle_len {
+                                        let dep_idx = (i + 1) % cycle_len;
+                                        DependencyInfo {
+                                            name: name.clone(),
+                                            depends_on: vec![DependsOn {
+                                                container_name: names[dep_idx].clone(),
+                                                condition: DependencyCondition::Start,
+                                            }],
+                                        }
+                                    } else {
+                                        DependencyInfo {
+                                            name: name.clone(),
+                                            depends_on: vec![],
+                                        }
+                                    }
+                                })
+                                .collect(),
+                        )
+                    })
+                    .boxed()
+            })
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(200))]
+
+            /// Property: A valid DAG always produces a successful result.
+            #[test]
+            fn dag_always_resolves(deps in arb_dag(8)) {
+                let result = resolve_start_order(&deps);
+                prop_assert!(result.is_ok(), "DAG should resolve but got: {:?}", result.err());
+            }
+
+            /// Property: All nodes appear in exactly one layer.
+            #[test]
+            fn all_nodes_in_exactly_one_layer(deps in arb_dag(8)) {
+                let layers = resolve_start_order(&deps).expect("should resolve");
+                let all_names: Vec<&str> = layers.iter().flat_map(|l| l.iter().map(String::as_str)).collect();
+                let unique: HashSet<&str> = all_names.iter().copied().collect();
+
+                // No duplicates
+                prop_assert_eq!(all_names.len(), unique.len(), "duplicate nodes in layers");
+
+                // All input nodes present
+                for d in &deps {
+                    prop_assert!(unique.contains(d.name.as_str()), "missing node: {}", d.name);
+                }
+            }
+
+            /// Property: Dependencies are satisfied — every node appears in a
+            /// layer after all its dependencies.
+            #[test]
+            fn dependencies_precede_dependents(deps in arb_dag(8)) {
+                let layers = resolve_start_order(&deps).expect("should resolve");
+
+                // Build name -> layer index map
+                let mut layer_of: HashMap<&str, usize> = HashMap::new();
+                for (li, layer) in layers.iter().enumerate() {
+                    for name in layer {
+                        layer_of.insert(name.as_str(), li);
+                    }
+                }
+
+                for d in &deps {
+                    let my_layer = layer_of[d.name.as_str()];
+                    for dep in &d.depends_on {
+                        if let Some(&dep_layer) = layer_of.get(dep.container_name.as_str()) {
+                            prop_assert!(
+                                dep_layer < my_layer,
+                                "container '{}' (layer {}) depends on '{}' (layer {}), but dependency is not in an earlier layer",
+                                d.name, my_layer, dep.container_name, dep_layer
+                            );
+                        }
+                    }
+                }
+            }
+
+            /// Property: Nodes within the same layer have no mutual dependencies.
+            #[test]
+            fn same_layer_nodes_are_independent(deps in arb_dag(8)) {
+                let layers = resolve_start_order(&deps).expect("should resolve");
+                let dep_map: HashMap<&str, HashSet<&str>> = deps.iter().map(|d| {
+                    (d.name.as_str(), d.depends_on.iter().map(|dep| dep.container_name.as_str()).collect())
+                }).collect();
+
+                for layer in &layers {
+                    let layer_set: HashSet<&str> = layer.iter().map(String::as_str).collect();
+                    for name in layer {
+                        if let Some(my_deps) = dep_map.get(name.as_str()) {
+                            for dep_name in my_deps {
+                                prop_assert!(
+                                    !layer_set.contains(dep_name),
+                                    "'{}' and its dependency '{}' are in the same layer",
+                                    name, dep_name
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            /// Property: Each layer is sorted (deterministic output).
+            #[test]
+            fn layers_are_sorted(deps in arb_dag(8)) {
+                let layers = resolve_start_order(&deps).expect("should resolve");
+                for layer in &layers {
+                    let mut sorted = layer.clone();
+                    sorted.sort();
+                    prop_assert_eq!(layer, &sorted, "layer should be sorted");
+                }
+            }
+
+            /// Property: A graph with a cycle always returns CyclicDependency error.
+            #[test]
+            fn cyclic_graph_always_fails(deps in arb_cyclic_graph()) {
+                let result = resolve_start_order(&deps);
+                prop_assert!(
+                    matches!(result, Err(OrchestratorError::CyclicDependency(_))),
+                    "cyclic graph should fail with CyclicDependency, got: {:?}",
+                    result
+                );
+            }
+
+            /// Property: Empty input produces empty output.
+            #[test]
+            fn empty_input_empty_output(_seed in 0u32..100u32) {
+                let result = resolve_start_order(&[]).expect("empty should resolve");
+                prop_assert!(result.is_empty());
+            }
+        }
     }
 
     fn make_inspection(id: &str, health_status: Option<&str>) -> ContainerInspection {

--- a/src/taskdef/diagnostics.rs
+++ b/src/taskdef/diagnostics.rs
@@ -1097,6 +1097,264 @@ mod tests {
 
     // --- validate_extended integration with all checks ---
 
+    // --- Property-based tests ---
+
+    mod pbt {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Generate a valid Docker image name: alphanumeric start, no whitespace,
+        /// no leading/trailing `/` or `:`, no `//` or `::`.
+        fn arb_valid_image() -> impl Strategy<Value = String> {
+            // registry/name:tag pattern
+            (
+                "[a-z0-9][a-z0-9.-]{0,15}",                         // registry or name
+                proptest::option::of("/[a-z0-9][a-z0-9.-]{0,10}"),  // optional path
+                proptest::option::of(":[a-z0-9][a-z0-9._-]{0,15}"), // optional tag
+            )
+                .prop_map(|(name, path, tag)| {
+                    let mut image = name;
+                    if let Some(p) = path {
+                        image.push_str(&p);
+                    }
+                    if let Some(t) = tag {
+                        image.push_str(&t);
+                    }
+                    image
+                })
+        }
+
+        /// Build a minimal valid `TaskDefinition` with given containers.
+        #[allow(clippy::type_complexity)]
+        fn make_task_def_with_containers(
+            containers: Vec<(String, String, Vec<(u16, Option<u16>, String)>)>,
+        ) -> TaskDefinition {
+            use crate::taskdef::*;
+            TaskDefinition {
+                family: "test".into(),
+                task_role_arn: None,
+                execution_role_arn: None,
+                volumes: vec![],
+                container_definitions: containers
+                    .into_iter()
+                    .map(|(name, image, ports)| ContainerDefinition {
+                        name,
+                        image,
+                        port_mappings: ports
+                            .into_iter()
+                            .map(|(cp, hp, proto)| PortMapping {
+                                container_port: cp,
+                                host_port: hp,
+                                protocol: proto,
+                            })
+                            .collect(),
+                        ..Default::default()
+                    })
+                    .collect(),
+            }
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(300))]
+
+            /// Property: Valid image names produce no diagnostics.
+            #[test]
+            fn valid_image_no_diagnostic(image in arb_valid_image()) {
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_none(), "valid image '{}' should not produce diagnostic: {:?}", image, result);
+            }
+
+            /// Property: Images with whitespace always produce an error.
+            #[test]
+            fn image_with_whitespace_is_error(
+                prefix in "[a-z]{1,5}",
+                ws in "[ \t\n\r]",
+                suffix in "[a-z]{1,5}",
+            ) {
+                let image = format!("{prefix}{ws}{suffix}");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' with whitespace should be rejected", image);
+                prop_assert_eq!(result.as_ref().map(|d| d.severity), Some(Severity::Error));
+            }
+
+            /// Property: Empty image always produces an error.
+            #[test]
+            fn empty_image_is_error(_seed in 0u32..10u32) {
+                let result = check_image_format("", "test");
+                prop_assert!(result.is_some());
+                prop_assert_eq!(result.as_ref().map(|d| d.severity), Some(Severity::Error));
+            }
+
+            /// Property: Images starting with '/' always produce an error.
+            #[test]
+            fn leading_slash_is_error(rest in "[a-z0-9]{1,10}") {
+                let image = format!("/{rest}");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' should be rejected", image);
+            }
+
+            /// Property: Images ending with '/' always produce an error.
+            #[test]
+            fn trailing_slash_is_error(prefix in "[a-z0-9]{1,10}") {
+                let image = format!("{prefix}/");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' should be rejected", image);
+            }
+
+            /// Property: Images starting with ':' always produce an error.
+            #[test]
+            fn leading_colon_is_error(rest in "[a-z0-9]{1,10}") {
+                let image = format!(":{rest}");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' should be rejected", image);
+            }
+
+            /// Property: Images ending with ':' always produce an error.
+            #[test]
+            fn trailing_colon_is_error(prefix in "[a-z0-9]{1,10}") {
+                let image = format!("{prefix}:");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' should be rejected", image);
+            }
+
+            /// Property: Images containing '//' always produce an error.
+            #[test]
+            fn double_slash_is_error(
+                prefix in "[a-z0-9]{1,5}",
+                suffix in "[a-z0-9]{1,5}",
+            ) {
+                let image = format!("{prefix}//{suffix}");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' should be rejected", image);
+            }
+
+            /// Property: Images containing '::' always produce an error.
+            #[test]
+            fn double_colon_is_error(
+                prefix in "[a-z0-9]{1,5}",
+                suffix in "[a-z0-9]{1,5}",
+            ) {
+                let image = format!("{prefix}::{suffix}");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' should be rejected", image);
+            }
+
+            /// Property: Images not starting with alphanumeric always produce an error.
+            #[test]
+            fn non_alphanumeric_start_is_error(
+                first in "[^a-zA-Z0-9/ :\t\n\r]",
+                rest in "[a-z0-9]{0,10}",
+            ) {
+                let image = format!("{first}{rest}");
+                let result = check_image_format(&image, "test");
+                prop_assert!(result.is_some(), "image '{}' starting with non-alphanumeric should be rejected", image);
+            }
+
+            /// Property: All diagnostics from check_image_format are Error severity.
+            #[test]
+            fn image_diagnostics_are_always_errors(image in "\\PC{1,30}") {
+                if let Some(d) = check_image_format(&image, "test") {
+                    prop_assert_eq!(d.severity, Severity::Error, "image format diagnostics should always be Error");
+                }
+            }
+
+            /// Property: Port conflicts are commutative — if we swap container order,
+            /// we still detect the same number of conflicts.
+            #[test]
+            fn port_conflict_count_independent_of_order(
+                port in 1u16..65535u16,
+                proto in prop_oneof![Just("tcp".to_string()), Just("udp".to_string())],
+            ) {
+                let td1 = make_task_def_with_containers(vec![
+                    ("a".into(), "alpine:latest".into(), vec![(port, Some(port), proto.clone())]),
+                    ("b".into(), "alpine:latest".into(), vec![(port, Some(port), proto.clone())]),
+                ]);
+                let td2 = make_task_def_with_containers(vec![
+                    ("b".into(), "alpine:latest".into(), vec![(port, Some(port), proto.clone())]),
+                    ("a".into(), "alpine:latest".into(), vec![(port, Some(port), proto)]),
+                ]);
+
+                let c1 = check_port_conflicts(&td1).len();
+                let c2 = check_port_conflicts(&td2).len();
+                prop_assert_eq!(c1, c2, "port conflict count should be order-independent");
+            }
+
+            /// Property: Distinct host ports never produce conflicts.
+            #[test]
+            fn distinct_ports_no_conflict(
+                port1 in 1u16..32000u16,
+                port2 in 32001u16..65535u16,
+            ) {
+                let td = make_task_def_with_containers(vec![
+                    ("a".into(), "alpine:latest".into(), vec![(80, Some(port1), "tcp".into())]),
+                    ("b".into(), "alpine:latest".into(), vec![(80, Some(port2), "tcp".into())]),
+                ]);
+                prop_assert!(check_port_conflicts(&td).is_empty());
+            }
+
+            /// Property: Same host port but different protocols don't conflict.
+            #[test]
+            fn same_port_different_protocol_no_conflict(port in 1u16..65535u16) {
+                let td = make_task_def_with_containers(vec![
+                    ("a".into(), "alpine:latest".into(), vec![(80, Some(port), "tcp".into())]),
+                    ("b".into(), "alpine:latest".into(), vec![(80, Some(port), "udp".into())]),
+                ]);
+                prop_assert!(check_port_conflicts(&td).is_empty());
+            }
+
+            /// Property: Valid ARNs produce no warnings.
+            #[test]
+            fn valid_secret_arn_no_warning(
+                region in "(us|eu|ap)-(east|west|central)-[1-3]",
+                account in "[0-9]{12}",
+                name in "[a-zA-Z][a-zA-Z0-9_-]{0,20}",
+            ) {
+                let arn = format!("arn:aws:secretsmanager:{region}:{account}:secret:{name}");
+                let td = TaskDefinition {
+                    family: "test".into(),
+                    task_role_arn: None,
+                    execution_role_arn: None,
+                    volumes: vec![],
+                    container_definitions: vec![crate::taskdef::ContainerDefinition {
+                        name: "app".into(),
+                        image: "alpine:latest".into(),
+                        secrets: vec![crate::taskdef::Secret {
+                            name: "SECRET".into(),
+                            value_from: arn,
+                        }],
+                        ..Default::default()
+                    }],
+                };
+                let diags = check_secret_arn_format(&td);
+                prop_assert!(diags.is_empty(), "valid ARN should produce no warnings: {:?}", diags);
+            }
+
+            /// Property: validate_extended never panics on arbitrary valid task definitions.
+            #[test]
+            fn validate_extended_never_panics(
+                family in "[a-zA-Z][a-zA-Z0-9_-]{0,10}",
+                n_containers in 1usize..=5usize,
+            ) {
+                let containers: Vec<_> = (0..n_containers)
+                    .map(|i| crate::taskdef::ContainerDefinition {
+                        name: format!("c{i}"),
+                        image: "alpine:latest".into(),
+                        ..Default::default()
+                    })
+                    .collect();
+                let td = TaskDefinition {
+                    family,
+                    task_role_arn: None,
+                    execution_role_arn: None,
+                    volumes: vec![],
+                    container_definitions: containers,
+                };
+                // Should not panic
+                let _report = validate_extended(&td);
+            }
+        }
+    }
+
     #[test]
     fn validate_extended_collects_all_issues() {
         let td = make_task_def(

--- a/src/taskdef/mod.rs
+++ b/src/taskdef/mod.rs
@@ -2158,4 +2158,139 @@ mod tests {
         assert_eq!(strip_quotes("\"mismatched'"), "\"mismatched'");
         assert_eq!(strip_quotes("\"\""), "");
     }
+
+    // --- Property-based tests ---
+
+    mod pbt {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(500))]
+
+            /// Property: strip_quotes never increases string length.
+            #[test]
+            fn strip_quotes_never_increases_length(s in ".*") {
+                prop_assert!(strip_quotes(&s).len() <= s.len());
+            }
+
+            /// Property: strip_quotes is idempotent — applying it twice
+            /// gives the same result as applying it once.
+            #[test]
+            fn strip_quotes_idempotent(s in ".*") {
+                let once = strip_quotes(&s);
+                let twice = strip_quotes(&once);
+                prop_assert_eq!(&once, &twice, "strip_quotes should be idempotent");
+            }
+
+            /// Property: Double-quoted strings are correctly unwrapped.
+            #[test]
+            fn strip_quotes_double_quoted(inner in "[^\"]*") {
+                let quoted = format!("\"{inner}\"");
+                prop_assert_eq!(strip_quotes(&quoted), inner);
+            }
+
+            /// Property: Single-quoted strings are correctly unwrapped.
+            #[test]
+            fn strip_quotes_single_quoted(inner in "[^']*") {
+                let quoted = format!("'{inner}'");
+                prop_assert_eq!(strip_quotes(&quoted), inner);
+            }
+
+            /// Property: Strings without matching quotes are returned unchanged.
+            #[test]
+            fn strip_quotes_unquoted_unchanged(s in "[^'\"][^'\"]*") {
+                prop_assert_eq!(strip_quotes(&s), s);
+            }
+
+            /// Property: Mismatched quotes are returned unchanged.
+            #[test]
+            fn strip_quotes_mismatched_unchanged(inner in ".{0,20}") {
+                let dq_sq = format!("\"{inner}'");
+                prop_assert_eq!(strip_quotes(&dq_sq), dq_sq);
+
+                let sq_dq = format!("'{inner}\"");
+                prop_assert_eq!(strip_quotes(&sq_dq), sq_dq);
+            }
+
+            /// Property: Single-character strings are never stripped.
+            #[test]
+            fn strip_quotes_single_char_unchanged(c in proptest::char::any()) {
+                let s = c.to_string();
+                prop_assert_eq!(strip_quotes(&s), s);
+            }
+
+            /// Property: Valid TaskDefinition JSON always parses successfully
+            /// when given well-formed input.
+            #[test]
+            fn valid_taskdef_json_parses(
+                family in "[a-zA-Z][a-zA-Z0-9_-]{0,20}",
+                name in "[a-zA-Z][a-zA-Z0-9_-]{0,20}",
+                tag in "[a-zA-Z0-9][a-zA-Z0-9._-]{0,15}",
+            ) {
+                let json = format!(
+                    r#"{{
+                        "family": "{family}",
+                        "containerDefinitions": [{{
+                            "name": "{name}",
+                            "image": "alpine:{tag}"
+                        }}]
+                    }}"#
+                );
+                let result = TaskDefinition::from_json(&json);
+                prop_assert!(result.is_ok(), "valid JSON should parse: {:?}", result.err());
+            }
+
+            /// Property: Container names matching ECS rules [a-zA-Z0-9_-]{1,255}
+            /// always pass validation.
+            #[test]
+            fn valid_container_names_pass(name in "[a-zA-Z0-9_-]{1,50}") {
+                let json = format!(
+                    r#"{{
+                        "family": "test",
+                        "containerDefinitions": [{{
+                            "name": "{name}",
+                            "image": "alpine:latest"
+                        }}]
+                    }}"#
+                );
+                let result = TaskDefinition::from_json(&json);
+                prop_assert!(result.is_ok(), "valid container name '{}' should pass: {:?}", name, result.err());
+            }
+
+            /// Property: Absolute paths without '..' pass validate_path_safety.
+            #[test]
+            fn absolute_paths_without_traversal_pass(
+                segments in proptest::collection::vec("[a-z][a-z0-9]{0,10}", 1..=5)
+            ) {
+                let path = format!("/{}", segments.join("/"));
+                let result = TaskDefinition::validate_path_safety(&path, "test", "ctx");
+                prop_assert!(result.is_ok(), "path '{}' should be safe: {:?}", path, result.err());
+            }
+
+            /// Property: Paths containing '..' always fail validate_path_safety.
+            #[test]
+            fn paths_with_traversal_fail(
+                prefix_segments in proptest::collection::vec("[a-z]{1,5}", 1..=3),
+                suffix_segments in proptest::collection::vec("[a-z]{1,5}", 0..=2),
+            ) {
+                let prefix = prefix_segments.join("/");
+                let suffix = suffix_segments.join("/");
+                let path = if suffix.is_empty() {
+                    format!("/{prefix}/..")
+                } else {
+                    format!("/{prefix}/../{suffix}")
+                };
+                let result = TaskDefinition::validate_path_safety(&path, "test", "ctx");
+                prop_assert!(result.is_err(), "path '{}' should be rejected", path);
+            }
+
+            /// Property: Relative paths always fail validate_path_safety.
+            #[test]
+            fn relative_paths_fail(path in "[a-z][a-z/]{0,20}") {
+                let result = TaskDefinition::validate_path_safety(&path, "test", "ctx");
+                prop_assert!(result.is_err(), "relative path '{}' should be rejected", path);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Introduce PBT for the three highest-priority areas:

- orchestrator::resolve_start_order: DAG properties (all nodes present,
  dependencies precede dependents, same-layer independence, sorted layers,
  cyclic graphs always rejected)
- taskdef::strip_quotes: idempotency, length, roundtrip for quoted/unquoted
  strings, path safety validation properties
- taskdef::diagnostics: image format validation, port conflict detection
  (commutativity, distinct ports), secret ARN format, validate_extended
  robustness

Also derives Debug+Clone on DependencyInfo for proptest compatibility.

https://claude.ai/code/session_01FDpeYwQGje6ZWmeswuVT4f