### PR TITLE
feat: add automatic image pull before container creation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -311,5 +311,5 @@ Phase 0-2.5: ✅ 完了
 - Prometheus / Grafana 等の外部監視スタック連携
 - awsvpc ネットワークモード完全再現
 - Service Mesh / Service Connect
-- ECR push/pull（Docker CLI の責務）
+- ECR 認証付き push/pull（Docker CLI の責務、匿名 pull は自動実行）
 - Cluster / Container Instance 管理（ローカルでは不要）

--- a/docs/design/auto-image-pull.md
+++ b/docs/design/auto-image-pull.md
@@ -1,0 +1,241 @@
+# 自動イメージ pull 設計書
+
+## 概要
+
+コンテナ作成前にイメージを自動的に pull する機能。bollard の `create_image` API（Docker Engine API `POST /images/create`）を使用し、ユーザーが手動で `docker pull` する手間を排除する。
+
+**対応要件**: FR-2.7
+
+**解決する課題**: Docker Engine API の `create_container` はローカルにイメージが存在しない場合にエラーを返す（Docker CLI のように自動 pull しない）。開発者は `lecs run` の前に手動で `docker pull` する必要があり、特に初回起動やイメージ更新時にフリクションが発生していた。
+
+**成果**: `lecs run` 実行時にイメージが自動的に pull され、ローカルにキャッシュ済みのイメージは高速な no-op で通過する。
+
+**設計判断: orchestrator で pull する理由**:
+CLI 層（`run.rs`）で一括 pull する方式も考えられるが、`dependsOn` DAG の各レイヤーでコンテナを作成する直前に pull することで、(1) 不要なイメージの先行 pull を避け、(2) pull 失敗時の部分起動状態を orchestrator の既存エラーハンドリング（partial `StartupResult` 返却）に統合できる。
+
+---
+
+## データフロー
+
+### 初回起動（`orchestrate_startup`）
+
+```
+lecs run -f task-def.json
+    │
+    ▼
+orchestrate_startup(specs)
+    │
+    ▼ DAG レイヤーごと
+    │
+    ├── create_and_start_container(spec)
+    │     │
+    │     ├── parse_image_reference(spec.config.image)
+    │     │     → (repository, tag)
+    │     │
+    │     ├── client.pull_image(image)
+    │     │     → bollard::create_image(CreateImageOptions { from_image, tag })
+    │     │     → Stream<CreateImageInfo> を try_collect で消費
+    │     │     → 失敗時: OrchestratorError::Runtime → 部分 StartupResult で返却
+    │     │
+    │     ├── emit(ImagePulled, family, container_name, image)
+    │     │
+    │     ├── client.create_container(config)
+    │     │     → emit(Created)
+    │     │
+    │     └── client.start_container(id)
+    │           → emit(Started)
+    │
+    └── wait_for_condition() [次レイヤーへの待機]
+```
+
+### サービスモード再起動（`restart_container`）
+
+```
+restart_container(client, name, old_id, config)
+    │
+    ├── emit(Restarting)
+    │
+    ├── client.pull_image(config.image)        ← ベストエフォート
+    │     → 失敗時: tracing::warn のみ（再起動を中断しない）
+    │
+    ├── stop_container → remove_container
+    │
+    ├── create_container → start_container
+    │
+    └── update_container_id (metadata)
+```
+
+---
+
+## 準拠する標準
+
+| 標準 | 用途 |
+|------|------|
+| Docker Engine API `POST /images/create` | イメージ pull のプロトコル |
+| OCI Distribution Specification | レジストリからのイメージ配布 |
+| Docker イメージ参照形式 | `[registry/]repository[:tag\|@digest]` のパース |
+
+---
+
+## 技術選定
+
+| 候補 | 判断 | 理由 |
+|------|------|------|
+| bollard `create_image` | **採用** | 既存の bollard 依存を活用。`Stream<CreateImageInfo>` でプログレスを受け取れる（将来の進捗表示に拡張可能）|
+| Docker CLI ラップ (`docker pull`) | 不採用 | プロセス生成のオーバーヘッド、出力パースの脆弱性。bollard で統一すべき |
+| `create_container` のエラーから pull にフォールバック | 不採用 | 二重のエラーパスが複雑。「常に pull」の方が一貫性がある（キャッシュヒット時は高速） |
+
+新規依存クレートは不要（bollard 0.18 の既存 API を使用）。
+
+---
+
+## モジュール配置
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/container/mod.rs` | `pull_image` トレイトメソッド + `ContainerClient` 実装 + `parse_image_reference` ヘルパー + `MockContainerClient` 拡張 |
+| `src/orchestrator/mod.rs` | `create_and_start_container` にイメージ pull を挿入 |
+| `src/cli/task_lifecycle.rs` | `restart_container` にベストエフォート pull を追加 |
+| `src/events/mod.rs` | `EventType::ImagePulled` バリアント追加 |
+
+---
+
+## 型定義
+
+### `ContainerRuntime` トレイト拡張（`src/container/mod.rs`）
+
+```rust
+pub trait ContainerRuntime: Send + Sync {
+    // ... 既存メソッド ...
+
+    /// Pull a container image from a registry.
+    ///
+    /// The `image` parameter is the full image reference (e.g., `nginx:latest`,
+    /// `registry.example.com/app:v1.0`). The implementation should handle
+    /// splitting the reference into repository and tag components.
+    async fn pull_image(&self, image: &str) -> Result<(), ContainerError>;
+}
+```
+
+### `MockContainerClient` 拡張（`src/container/mod.rs`）
+
+```rust
+pub struct MockContainerClient {
+    // ... 既存フィールド ...
+    pub pull_image_results: Mutex<VecDeque<Result<(), ContainerError>>>,
+}
+```
+
+### `EventType` 拡張（`src/events/mod.rs`）
+
+```rust
+pub enum EventType {
+    /// Container image was pulled.
+    ImagePulled,
+    // ... 既存バリアント ...
+}
+```
+
+---
+
+## ヘルパー関数
+
+### `parse_image_reference`（`src/container/mod.rs`）
+
+```rust
+/// Parse an image reference into (repository, tag) components.
+fn parse_image_reference(image: &str) -> (&str, &str)
+```
+
+イメージ参照文字列を bollard `CreateImageOptions` に渡す `from_image` と `tag` に分離する。
+
+**パースルール**:
+
+| 入力 | `from_image` | `tag` | 説明 |
+|------|-------------|-------|------|
+| `nginx` | `nginx` | `latest` | タグ省略時はデフォルト `latest` |
+| `nginx:1.25` | `nginx` | `1.25` | 基本形式 |
+| `library/nginx:alpine` | `library/nginx` | `alpine` | 名前空間付き |
+| `registry.example.com:5000/app` | `registry.example.com:5000/app` | `latest` | レジストリのポート番号をタグと誤認しない |
+| `registry.example.com:5000/app:v1` | `registry.example.com:5000/app` | `v1` | レジストリのポート + タグ |
+| `nginx@sha256:abc...` | `nginx@sha256:abc...` | `""` | digest 参照はそのまま（タグなし） |
+
+**アルゴリズム**:
+1. `@` を含む → digest 参照。`(image, "")` を返す
+2. 最後の `/` の位置を特定（レジストリ部分のポート番号のコロンを除外）
+3. `/` 以降の部分で最後の `:` を探す → タグの区切り
+4. `:` が見つからない → `(image, "latest")`
+
+---
+
+## エラーハンドリング
+
+| シナリオ | 挙動 | 理由 |
+|----------|------|------|
+| イメージが存在しない（404） | `ContainerError::Api` → `OrchestratorError::Runtime` → タスク起動中止 | 存在しないイメージでの起動は必ず失敗する |
+| レジストリ接続エラー | 同上 | ネットワーク問題はリトライで解決しない可能性が高い |
+| ローカルキャッシュのみ利用（レジストリ未到達）| Docker Engine がキャッシュから解決 | Docker Engine API の標準動作 |
+| サービスモード再起動時の pull 失敗 | `tracing::warn` のみで続行 | リスタートをブロックすべきでない（イメージはローカルにある可能性が高い） |
+
+### 初回起動 vs サービスモードの非対称設計
+
+初回起動時はイメージが存在しない可能性が高いため、pull 失敗はハードエラーにする。一方、サービスモードの再起動時は直前まで同じイメージで動作していたため、pull 失敗しても既存キャッシュで `create_container` が成功する可能性が高い。このため、再起動時はベストエフォート（警告のみ）とする。
+
+---
+
+## テスト戦略
+
+| テスト対象 | テスト数 | カテゴリ |
+|-----------|---------|---------|
+| `parse_image_reference` — 基本名 | 1 | ユニット |
+| `parse_image_reference` — タグ付き | 1 | ユニット |
+| `parse_image_reference` — レジストリ+ポート | 1 | ユニット |
+| `parse_image_reference` — レジストリ+ポート+タグ | 1 | ユニット |
+| `parse_image_reference` — digest 参照 | 1 | ユニット |
+| `parse_image_reference` — 名前空間付き | 1 | ユニット |
+| `orchestrate_startup` — image pull 失敗 | 1 | ユニット |
+| `orchestrate_startup` — 正常起動（pull 成功込み） | 4 (既存修正) | ユニット |
+| `restart_container` — pull 成功込み | 6 (既存修正) | ユニット |
+| `run_task` — pull 成功込み | 3 (既存修正) | ユニット |
+
+新規テスト: 7、既存テスト修正: 13（`pull_image_results` エンキュー追加）
+
+合計テスト数: 585 → 592
+
+---
+
+## ライフサイクルイベント
+
+`ImagePulled` イベントは `--events` フラグ有効時に NDJSON で出力される:
+
+```json
+{
+  "timestamp": "2026-04-07T12:00:00.000Z",
+  "event_type": "image_pulled",
+  "container_name": "app",
+  "family": "my-app",
+  "details": "nginx:latest"
+}
+```
+
+イベント発行タイミング: `pull_image()` 成功直後、`create_container()` 直前。
+
+---
+
+## 制限事項
+
+- **レジストリ認証**: bollard `create_image` の `credentials` パラメータは `None` を渡しており、認証付きレジストリ（ECR、GCR 等）への pull は未対応。Docker/Podman のローカル認証情報（`~/.docker/config.json`）はランタイム側で処理される場合がある
+- **プログレス表示**: `create_image` が返す `Stream<CreateImageInfo>` を `try_collect` で消費しており、レイヤーごとの進捗表示は行わない（将来の拡張ポイント）
+- **並列 pull**: 同一レイヤー内の複数コンテナのイメージ pull は順次実行。並列化は将来の最適化候補
+- **pull スキップオプション**: `--no-pull` のようなフラグでオフライン環境向けに pull をスキップする機能は未実装（将来対応）
+
+---
+
+## 将来の拡張ポイント
+
+| 項目 | 優先度 | 説明 |
+|------|--------|------|
+| `--no-pull` フラグ | 中 | オフライン環境・CI でイメージ pull をスキップ |
+| プログレス表示 | 低 | レイヤーごとの pull 進捗を stderr に表示 |
+| 並列 pull | 低 | 同一レイヤー内の複数イメージを `tokio::join!` で並列 pull |
+| レジストリ認証 | 低 | `executionRoleArn` を活用した ECR 認証（Docker CLI の責務と重複） |

--- a/docs/design/container.md
+++ b/docs/design/container.md
@@ -212,6 +212,7 @@ pub trait ContainerRuntime: Send + Sync {
     async fn list_containers(&self, task_filter: Option<&str>) -> Result<Vec<ContainerInfo>, ContainerError>;
     async fn inspect_container(&self, id: &str) -> Result<ContainerInspection, ContainerError>;
     async fn wait_container(&self, id: &str) -> Result<WaitResult, ContainerError>;
+    async fn pull_image(&self, image: &str) -> Result<(), ContainerError>;
 }
 ```
 
@@ -360,7 +361,7 @@ let networking_config = NetworkingConfig {
 | エラー状況 | ContainerError バリアント | 対応 |
 |---|---|---|
 | コンテナランタイム未起動 | `RuntimeNotRunning` | `connect()` で ping 失敗時に検出 |
-| イメージが存在しない | `Api(...)` | ランタイムがデフォルトで pull を試行 |
+| イメージ pull 失敗 | `Api(...)` | コンテナ作成前の `pull_image` で検出・報告 |
 | ポート競合 | `Api(...)` | ランタイム API エラーをそのまま伝搬 |
 | ネットワーク既存 | — | `create_network` 内で既存を検出し再利用（エラーにしない） |
 | コンテナ停止タイムアウト | `Api(...)` | 10 秒後にランタイムが自動 kill |
@@ -387,8 +388,22 @@ let networking_config = NetworkingConfig {
 - `wait_container()`: コンテナの終了を待機（`bollard::Docker::wait_container` の Stream から最初のアイテムを取得）
 - `MockContainerClient` に `inspect_container_results` / `wait_container_results` キューを追加
 
+## 自動イメージ pull
+
+コンテナ作成前に `pull_image()` で自動的にイメージを pull する。
+
+- bollard の `create_image` API（Docker Engine API `POST /images/create`）を使用
+- イメージ参照を repository と tag に分離する `parse_image_reference()` ヘルパー
+  - `nginx` → `("nginx", "latest")`
+  - `nginx:1.25` → `("nginx", "1.25")`
+  - `registry.example.com:5000/app:v1` → `("registry.example.com:5000/app", "v1")`
+  - `nginx@sha256:abc...` → digest 参照としてそのまま渡す
+- ローカルにキャッシュ済みのイメージは高速な no-op
+- `orchestrate_startup()` の各コンテナ作成前に実行
+- `restart_container()` でもベストエフォートで再 pull（失敗時は警告のみで続行）
+- `ImagePulled` ライフサイクルイベントを発行
+
 ## 制限事項
 
-- イメージの明示的な pull 制御は未実装（ランタイムのデフォルト動作に委ねる）
 - コンテナのリソース制限（CPU/メモリ）は設定するが、厳密な enforcement はランタイムに委ねる
 - ボリュームマウントは未対応 → Phase 5

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -30,6 +30,7 @@ ECS タスク定義をローカルで実行し、ECS アプリが期待する実
 | FR-2.4 | 複数コンテナの順次起動に対応する | ✅ 実装済み |
 | FR-2.5 | コンテナのログをプレフィックス付きでストリーム表示する | ✅ 実装済み |
 | FR-2.6 | `Ctrl+C` でグレースフルシャットダウンする | ✅ 実装済み |
+| FR-2.7 | コンテナ作成前にイメージを自動で pull する | ✅ 実装済み |
 
 ### FR-3: コンテナ停止
 
@@ -206,5 +207,5 @@ ECS タスク定義をローカルで実行し、ECS アプリが期待する実
 - Prometheus / Grafana 等の外部監視スタック連携
 - awsvpc ネットワークモード完全再現
 - Service Mesh / Service Connect
-- ECR push/pull（Docker CLI の責務）
+- ECR 認証付き push/pull（Docker CLI の責務、匿名 pull は自動実行）
 - Cluster / Container Instance 管理（ローカルでは不要）

--- a/src/cli/task_lifecycle.rs
+++ b/src/cli/task_lifecycle.rs
@@ -170,6 +170,11 @@ pub async fn restart_container(
         None,
     ));
 
+    // Pull the image before restarting (no-op if already cached)
+    if let Err(e) = client.pull_image(&config.image).await {
+        tracing::warn!(container = %container_name, error = %e, "Image pull failed during restart (continuing)");
+    }
+
     if let Some(id) = old_id {
         // Best-effort stop: already-stopped containers are fine.
         if let Err(e) = client.stop_container(id, None).await {
@@ -488,6 +493,7 @@ mod tests {
     async fn run_task_single_container() {
         let mock = MockContainerClient {
             create_network_results: Mutex::new(VecDeque::from([Ok("lecs-web".to_string())])),
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([Ok("container-1".to_string())])),
             start_container_results: Mutex::new(VecDeque::from([Ok(())])),
             ..MockContainerClient::new()
@@ -508,6 +514,7 @@ mod tests {
     async fn run_task_multi_container() {
         let mock = MockContainerClient {
             create_network_results: Mutex::new(VecDeque::from([Ok("lecs-multi".to_string())])),
+            pull_image_results: Mutex::new(VecDeque::from([Ok(()), Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([
                 Ok("c1".to_string()),
                 Ok("c2".to_string()),
@@ -544,6 +551,7 @@ mod tests {
     async fn run_task_container_create_failure() {
         let mock = MockContainerClient {
             create_network_results: Mutex::new(VecDeque::from([Ok("lecs-multi".to_string())])),
+            pull_image_results: Mutex::new(VecDeque::from([Ok(()), Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([
                 Ok("c1".to_string()),
                 Err(crate::container::ContainerError::RuntimeNotRunning),
@@ -639,6 +647,7 @@ mod tests {
         use crate::events::CollectingEventSink;
 
         let mock = MockContainerClient {
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             stop_container_results: Mutex::new(VecDeque::from([Ok(())])),
             remove_container_results: Mutex::new(VecDeque::from([Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([Ok("new-id".to_string())])),
@@ -687,6 +696,7 @@ mod tests {
         use crate::events::CollectingEventSink;
 
         let mock = MockContainerClient {
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             stop_container_results: Mutex::new(VecDeque::from([Err(
                 crate::container::ContainerError::RuntimeNotRunning,
             )])),
@@ -719,6 +729,7 @@ mod tests {
         use crate::events::CollectingEventSink;
 
         let mock = MockContainerClient {
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             stop_container_results: Mutex::new(VecDeque::from([Ok(())])),
             remove_container_results: Mutex::new(VecDeque::from([Err(
                 crate::container::ContainerError::RuntimeNotRunning,
@@ -749,6 +760,7 @@ mod tests {
         use crate::events::CollectingEventSink;
 
         let mock = MockContainerClient {
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             stop_container_results: Mutex::new(VecDeque::from([Ok(())])),
             remove_container_results: Mutex::new(VecDeque::from([Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([Err(
@@ -780,6 +792,7 @@ mod tests {
         use crate::events::CollectingEventSink;
 
         let mock = MockContainerClient {
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             stop_container_results: Mutex::new(VecDeque::from([Ok(())])),
             remove_container_results: Mutex::new(VecDeque::from([Ok(()), Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([Ok("new-id".to_string())])),
@@ -813,6 +826,7 @@ mod tests {
 
         // old_id=None: stop/remove are skipped; only create/start are called.
         let mock = MockContainerClient {
+            pull_image_results: Mutex::new(VecDeque::from([Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([Ok("fresh-id".to_string())])),
             start_container_results: Mutex::new(VecDeque::from([Ok(())])),
             ..MockContainerClient::new()
@@ -1107,6 +1121,7 @@ mod tests {
     async fn run_task_with_dependencies() {
         let mock = MockContainerClient {
             create_network_results: Mutex::new(VecDeque::from([Ok("lecs-test".to_string())])),
+            pull_image_results: Mutex::new(VecDeque::from([Ok(()), Ok(())])),
             create_container_results: Mutex::new(VecDeque::from([
                 Ok("db-id".to_string()),
                 Ok("app-id".to_string()),

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -8,6 +8,7 @@ use bollard::container::{
     RemoveContainerOptions, StatsOptions, StopContainerOptions,
 };
 use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::image::CreateImageOptions;
 use bollard::models::{EndpointSettings, HealthConfig, HostConfig, PortBinding, ResourcesUlimits};
 use bollard::network::{CreateNetworkOptions, ListNetworksOptions};
 use futures_util::Stream;
@@ -71,6 +72,13 @@ pub trait ContainerRuntime: Send + Sync {
 
     /// Execute a command inside a running container.
     async fn exec_container(&self, id: &str, cmd: &[String]) -> Result<ExecResult, ContainerError>;
+
+    /// Pull a container image from a registry.
+    ///
+    /// The `image` parameter is the full image reference (e.g., `nginx:latest`,
+    /// `registry.example.com/app:v1.0`). The implementation should handle
+    /// splitting the reference into repository and tag components.
+    async fn pull_image(&self, image: &str) -> Result<(), ContainerError>;
 }
 
 /// Result of executing a command inside a container.
@@ -253,6 +261,31 @@ fn parse_host_url(url: &str) -> (HostScheme, &str) {
         },
         |path| (HostScheme::Unix, path),
     )
+}
+
+/// Parse an image reference into (repository, tag) components.
+///
+/// Handles the following formats:
+/// - `nginx` → `("nginx", "latest")`
+/// - `nginx:1.25` → `("nginx", "1.25")`
+/// - `registry.example.com:5000/app` → `("registry.example.com:5000/app", "latest")`
+/// - `registry.example.com:5000/app:v1` → `("registry.example.com:5000/app", "v1")`
+/// - `nginx@sha256:abc...` → `("nginx@sha256:abc...", "")` (digest reference, no tag)
+fn parse_image_reference(image: &str) -> (&str, &str) {
+    // Digest reference — pass through as-is with empty tag
+    if image.contains('@') {
+        return (image, "");
+    }
+
+    // Find the last colon that is part of the tag (not a port number).
+    // A colon in a tag comes after the last `/` (if any).
+    let after_last_slash = image.rfind('/').map_or(0, |i| i + 1);
+    image[after_last_slash..]
+        .rfind(':')
+        .map_or((image, "latest"), |offset| {
+            let colon_pos = after_last_slash + offset;
+            (&image[..colon_pos], &image[colon_pos + 1..])
+        })
 }
 
 /// Return candidate socket paths for Podman runtime connection.
@@ -698,6 +731,23 @@ impl ContainerRuntime for ContainerClient {
             exit_code: inspect.exit_code,
         })
     }
+
+    async fn pull_image(&self, image: &str) -> Result<(), ContainerError> {
+        let (from_image, tag) = parse_image_reference(image);
+
+        let options = CreateImageOptions {
+            from_image,
+            tag,
+            ..Default::default()
+        };
+
+        self.docker
+            .create_image(Some(options), None, None)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        Ok(())
+    }
 }
 
 /// Calculate CPU usage percentage from a Docker stats snapshot.
@@ -896,6 +946,7 @@ pub mod test_support {
         pub wait_container_results: Mutex<VecDeque<Result<WaitResult, ContainerError>>>,
         pub stats_container_results: Mutex<VecDeque<Result<ContainerStats, ContainerError>>>,
         pub exec_container_results: Mutex<VecDeque<Result<ExecResult, ContainerError>>>,
+        pub pull_image_results: Mutex<VecDeque<Result<(), ContainerError>>>,
     }
 
     impl MockContainerClient {
@@ -913,6 +964,7 @@ pub mod test_support {
                 wait_container_results: Mutex::new(VecDeque::new()),
                 stats_container_results: Mutex::new(VecDeque::new()),
                 exec_container_results: Mutex::new(VecDeque::new()),
+                pull_image_results: Mutex::new(VecDeque::new()),
             }
         }
     }
@@ -996,6 +1048,10 @@ pub mod test_support {
             _cmd: &[String],
         ) -> Result<ExecResult, ContainerError> {
             pop_result(&self.exec_container_results)
+        }
+
+        async fn pull_image(&self, _image: &str) -> Result<(), ContainerError> {
+            pop_result(&self.pull_image_results)
         }
     }
 }
@@ -1393,5 +1449,45 @@ mod tests {
 
         let host_config = result.host_config.as_ref().expect("host_config");
         assert!(host_config.binds.is_none());
+    }
+
+    #[test]
+    fn parse_image_reference_simple_name() {
+        assert_eq!(parse_image_reference("nginx"), ("nginx", "latest"));
+    }
+
+    #[test]
+    fn parse_image_reference_with_tag() {
+        assert_eq!(parse_image_reference("nginx:1.25"), ("nginx", "1.25"));
+    }
+
+    #[test]
+    fn parse_image_reference_registry_with_port() {
+        assert_eq!(
+            parse_image_reference("registry.example.com:5000/app"),
+            ("registry.example.com:5000/app", "latest")
+        );
+    }
+
+    #[test]
+    fn parse_image_reference_registry_with_port_and_tag() {
+        assert_eq!(
+            parse_image_reference("registry.example.com:5000/app:v1"),
+            ("registry.example.com:5000/app", "v1")
+        );
+    }
+
+    #[test]
+    fn parse_image_reference_digest() {
+        let img = "nginx@sha256:abc123";
+        assert_eq!(parse_image_reference(img), (img, ""));
+    }
+
+    #[test]
+    fn parse_image_reference_namespaced() {
+        assert_eq!(
+            parse_image_reference("library/nginx:alpine"),
+            ("library/nginx", "alpine")
+        );
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -9,6 +9,8 @@ use serde::Serialize;
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
 pub enum EventType {
+    /// Container image was pulled.
+    ImagePulled,
     /// Container was created.
     Created,
     /// Container was started.

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -292,6 +292,8 @@ pub struct StartupResult {
 }
 
 /// Create and start a single container, emitting lifecycle events.
+///
+/// Automatically pulls the container image before creation.
 async fn create_and_start_container(
     client: &(impl ContainerRuntime + ?Sized),
     spec: &ContainerSpec,
@@ -305,6 +307,26 @@ async fn create_and_start_container(
         .get(crate::labels::TASK)
         .cloned()
         .unwrap_or_default();
+
+    // Pull the image before creating the container
+    let image = &spec.config.image;
+    tracing::info!(container = %name, image = %image, "Pulling image");
+    client.pull_image(image).await.map_err(|e| {
+        (
+            StartupResult {
+                started: started.to_vec(),
+            },
+            OrchestratorError::from(e),
+        )
+    })?;
+    event_sink.emit(&LifecycleEvent::new(
+        EventType::ImagePulled,
+        &family,
+        Some(name),
+        Some(image),
+    ));
+    tracing::info!(container = %name, image = %image, "Pulled image");
+
     let id = client.create_container(&spec.config).await.map_err(|e| {
         (
             StartupResult {
@@ -1381,6 +1403,7 @@ mod tests {
         let mock = MockContainerClient::new();
         // Two containers, no deps — both in layer 0
         for name in &["c1", "c2"] {
+            mock.pull_image_results.lock().unwrap().push_back(Ok(()));
             mock.create_container_results
                 .lock()
                 .unwrap()
@@ -1403,6 +1426,7 @@ mod tests {
         let mock = MockContainerClient::new();
         // a -> b (START condition)
         for name in &["a", "b"] {
+            mock.pull_image_results.lock().unwrap().push_back(Ok(()));
             mock.create_container_results
                 .lock()
                 .unwrap()
@@ -1430,6 +1454,7 @@ mod tests {
         let mock = MockContainerClient::new();
         // db (with healthcheck) -> app (HEALTHY)
         for name in &["db", "app"] {
+            mock.pull_image_results.lock().unwrap().push_back(Ok(()));
             mock.create_container_results
                 .lock()
                 .unwrap()
@@ -1477,6 +1502,26 @@ mod tests {
             .unwrap_err();
         assert!(
             matches!(err.1, OrchestratorError::CyclicDependency(_)),
+            "unexpected: {:?}",
+            err.1
+        );
+        assert!(err.0.started.is_empty());
+    }
+
+    #[tokio::test]
+    async fn orchestrate_startup_image_pull_failure() {
+        let mock = MockContainerClient::new();
+        mock.pull_image_results
+            .lock()
+            .unwrap()
+            .push_back(Err(crate::container::ContainerError::RuntimeNotRunning));
+
+        let specs = vec![make_spec("a", &[])];
+        let err = orchestrate_startup(&mock, specs, &NullEventSink)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err.1, OrchestratorError::Runtime(_)),
             "unexpected: {:?}",
             err.1
         );
@@ -1697,6 +1742,7 @@ mod tests {
     #[tokio::test]
     async fn orchestrate_startup_emits_created_and_started_events() {
         let mock = MockContainerClient::new();
+        mock.pull_image_results.lock().unwrap().push_back(Ok(()));
         mock.create_container_results
             .lock()
             .unwrap()
@@ -1712,8 +1758,9 @@ mod tests {
         assert_eq!(result.started.len(), 1);
 
         let events = sink.events();
-        assert_eq!(events.len(), 2);
-        assert!(matches!(events[0].event_type, EventType::Created));
-        assert!(matches!(events[1].event_type, EventType::Started));
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0].event_type, EventType::ImagePulled));
+        assert!(matches!(events[1].event_type, EventType::Created));
+        assert!(matches!(events[2].event_type, EventType::Started));
     }
 }


### PR DESCRIPTION
Pull container images automatically via bollard's create_image API
before creating containers. This eliminates the need for users to
manually pull images before running `lecs run`.

- Add `pull_image` method to `ContainerRuntime` trait
- Implement `parse_image_reference` to split image:tag correctly
  (handles registry ports, digests, and defaults to "latest")
- Orchestrator pulls images before each `create_container` call
- Service mode restart also pulls images (best-effort, warns on failure)
- Add `ImagePulled` lifecycle event type for observability
- Update design docs, requirements, and roadmap

https://claude.ai/code/session_01Vui6gBMxYE8mWngBX77umt